### PR TITLE
Add inert ChartDescriptor utility

### DIFF
--- a/src/com/github/ciacob/flexnodal/utils/ChartDescriptor.as
+++ b/src/com/github/ciacob/flexnodal/utils/ChartDescriptor.as
@@ -1,0 +1,44 @@
+package com.github.ciacob.flexnodal.utils {
+
+    import flash.geom.Point;
+
+    /**
+     * Immutable description of a chart instance.
+     */
+    public class ChartDescriptor {
+
+        private var _uid:String;
+        private var _values:Vector.<Point>;
+        private var _name:String;
+        private var _hueFactor:Number;
+        private var _dashStyle:Vector.<Number>;
+
+        public function ChartDescriptor(uid:String, values:Vector.<Point>, name:String = uid, hueFactor:Number = 0, dashStyle:Vector.<Number> = null) {
+            _uid = uid;
+            _values = values ? values.concat() : new Vector.<Point>();
+            _name = name;
+            _hueFactor = hueFactor;
+            _dashStyle = dashStyle ? dashStyle.concat() : null;
+        }
+
+        public function get uid():String {
+            return _uid;
+        }
+
+        public function get values():Vector.<Point> {
+            return _values.concat();
+        }
+
+        public function get name():String {
+            return _name;
+        }
+
+        public function get hueFactor():Number {
+            return _hueFactor;
+        }
+
+        public function get dashStyle():Vector.<Number> {
+            return _dashStyle ? _dashStyle.concat() : null;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add immutable ChartDescriptor for chart metadata with defensive copies and getters only

------
https://chatgpt.com/codex/tasks/task_e_68bec727767483299970fd7e7af4a466