### PR TITLE
Refactor NodalEvent to expose uid and remove payload

### DIFF
--- a/src/com/github/ciacob/flexnodal/events/NodalEvent.as
+++ b/src/com/github/ciacob/flexnodal/events/NodalEvent.as
@@ -10,15 +10,19 @@ package com.github.ciacob.flexnodal.events {
         public static const CHART_DATA_CHANGE:String = "chartDataChange";
         public static const CHART_ACTIVATION:String = "chartActivation";
 
-        public var payload:Object;
+        private var _uid:String;
 
-        public function NodalEvent (type:String, payload:Object = null, bubbles:Boolean = false, cancelable:Boolean = false) {
+        public function NodalEvent (type:String, uid:String, bubbles:Boolean = false, cancelable:Boolean = false) {
             super(type, bubbles, cancelable);
-            this.payload = payload;
+            _uid = uid;
+        }
+
+        public function get uid():String {
+            return _uid;
         }
 
         override public function clone():Event {
-            return new NodalEvent (type, payload, bubbles, cancelable);
+            return new NodalEvent (type, uid, bubbles, cancelable);
         }
     }
 }


### PR DESCRIPTION
## Summary
- replace generic payload with immutable uid property in NodalEvent
- adjust constructor and clone implementation to use uid

## Testing
- `mxmlc src/com/github/ciacob/flexnodal/events/NodalEvent.as` *(fails: command not found)*
- `apt-get install -y flex-sdk` *(fails: Unable to locate package flex-sdk)*

------
https://chatgpt.com/codex/tasks/task_e_68becdd276908329a6e33104b1f71a78