### PR TITLE
Refactor events and selection handling

### DIFF
--- a/src/com/github/ciacob/flexnodal/Nodal.mxml
+++ b/src/com/github/ciacob/flexnodal/Nodal.mxml
@@ -9,7 +9,7 @@
     <fx:Metadata>
         [Style(name="chartStyle", type="String", inherit="false")]
         
-        [Event(name="selectionChange", type="com.github.ciacob.flexnodal.events.NodalEvent")]
+        [Event(name="selectionChange", type="com.github.ciacob.flexnodal.events.SelectionEvent")]
         [Event(name="chartDataChange", type="com.github.ciacob.flexnodal.events.NodalEvent")]
         [Event(name="chartActivation", type="com.github.ciacob.flexnodal.events.NodalEvent")]
     </fx:Metadata>
@@ -19,6 +19,7 @@
             import com.github.ciacob.flexnodal.utils.InstanceFactory;
             import mx.core.UIComponent;
             import com.github.ciacob.flexnodal.events.NodalEvent;
+            import com.github.ciacob.flexnodal.events.SelectionEvent;
             import mx.collections.ArrayCollection;
             import com.github.ciacob.flexnodal.components.LineChartLayer;
             import com.github.ciacob.flexnodal.utils.Helpers;
@@ -29,6 +30,7 @@
             import com.github.ciacob.flexnodal.Nodal;
             import mx.events.CollectionEvent;
             import spark.filters.DropShadowFilter;
+            import com.github.ciacob.flexnodal.utils.SelectionDetails;
             
             /**
              * Overridable, global `DropShadowFilter` instance to be used underneath the active
@@ -244,7 +246,7 @@
             
             /**
              * Unselects all selected nodes of the active chart, if applicable.
-             * Dispatches a `NodalEvent.SELECTION_CHANGE` event.
+             * Dispatches a `SelectionEvent`.
              */
             public function clearSelection():void {
                 if (!_activeChart) {
@@ -268,7 +270,7 @@
              * Rewrites the values of all selected nodes of the active chart, if
              * applicable.
              */
-            public function patchSelection(patch:Object, dispatch:Boolean = false):void {
+            public function patchSelection(patch:SelectionDetails, dispatch:Boolean = false):void {
                 if (!_activeChart || !patch) {
                     return;
                 }
@@ -649,10 +651,10 @@
              * Listener. Executed when the active chart layer dispatched a `selectionChange`
              * event.
              */
-            private function _onSelectionChanged(event:NodalEvent):void {
-            
+            private function _onSelectionChanged(event:SelectionEvent):void {
+
                 // Re-dispatch on current target
-                dispatchEvent(new NodalEvent(NodalEvent.SELECTION_CHANGE, event.payload));
+                dispatchEvent(new SelectionEvent(NodalEvent.SELECTION_CHANGE, event.uid, event.details));
             }
             
             /**

--- a/src/com/github/ciacob/flexnodal/components/LineChartLayer.mxml
+++ b/src/com/github/ciacob/flexnodal/components/LineChartLayer.mxml
@@ -13,8 +13,8 @@
         
         [Style(name="padding", type="Number", inherit="false")]
         
-        [Event(name="selectionChange", type="com.github.ciacob.flexnodal.events.NodalEvent")]
-        [Event(name="nodesChange", type="com.github.ciacob.flexnodal.events.NodalEvent")]
+        [Event(name="selectionChange", type="com.github.ciacob.flexnodal.events.SelectionEvent")]
+        [Event(name="nodesChange", type="com.github.ciacob.flexnodal.events.ChartEditEvent")]
         [Event(name="layerClick", type="com.github.ciacob.flexnodal.events.NodalEvent")]
     </fx:Metadata>
 
@@ -27,14 +27,18 @@
             import flash.events.MouseEvent;
             import com.github.ciacob.flexnodal.utils.SelectionManager;
             import com.github.ciacob.flexnodal.events.NodalEvent;
+            import com.github.ciacob.flexnodal.events.SelectionEvent;
+            import com.github.ciacob.flexnodal.events.ChartEditEvent;
             import com.github.ciacob.flexnodal.utils.Helpers;
-            import com.github.ciacob.flexnodal.utils.Node;
+            import com.github.ciacob.flexnodal.utils.ChartDescriptor;
             import com.github.ciacob.flexnodal.utils.ChartCoordinates;
             import com.github.ciacob.flexnodal.utils.DragDeltas;
             import flash.geom.Rectangle;
             import flash.geom.Point;
             import com.github.ciacob.flexnodal.utils.DefaultStyles;
             import com.github.ciacob.flexnodal.utils.DashGraphics;
+            import com.github.ciacob.flexnodal.utils.SelectionDetails;
+            import com.github.ciacob.flexnodal.utils.ChartEdit;
             
             // Storage for the alternate graphics engine we use for drawing
             // dashed lines instead of solid lines.
@@ -97,21 +101,9 @@
             // The `dataProvider` property
             // ---------------------------
             
-            // An Object, containing at the very least a `values` Array
-            // property, preferably also containing a `name` and `colorIndex`.
-            
-            // The `values` property is expected to hold all logical [x,y]
-            // points that define this line chart.
-            // 
-            // More specifically, `values` should be an Array of user-provided
-            // doublets of abstract and normalized [x,y] values, such as:
-            // [ [0,0], [0.5,1], [1,0] ]
-            // 
-            // The above abstractly define a simple chart line
-            // that starts and ends at the very bottom on the Y axis,
-            // while climbing fully in its middle (on the X axis),
-            // thus creating a simple "hill" profile.
-            private var _dataProvider:Object;
+            // Immutable descriptor for this chart, providing an identifier,
+            // a friendly name and the list of logical points defining the chart.
+            private var _dataProvider:ChartDescriptor;
             
             // Flag to raise when the client code has externally changed
             // the input data provider.
@@ -121,7 +113,7 @@
              * Sets a new data provider. Causes the chart to be updated.
              */
             [Bindable]
-            public function set dataProvider(value:Object):void {
+            public function set dataProvider(value:ChartDescriptor):void {
                 _dataProvider = value;
                 _dataProviderChanged = true;
                 invalidateProperties();
@@ -131,7 +123,7 @@
              * Gets the current data provider. Its `values` will reflect
              * any changes the user has made to the chart meanwhile.
              */
-            public function get dataProvider():Object {
+            public function get dataProvider():ChartDescriptor {
                 return _dataProvider;
             }
             
@@ -194,7 +186,7 @@
              * Returns `null` otherwise.
              */
             public function get dashStyle():Vector.<Number> {
-                return _dashStyle? _dashStyle.concat() : null;
+                return (_dashStyle && _dashStyle.length > 0) ? _dashStyle.concat() : null;
             }
             
             // ----------------------
@@ -300,7 +292,6 @@
                     _nodes = _proofNodes(_nodes);
                     _provisionMarkers(_nodes, _markerLayer);
                     invalidateDisplayList();
-                    _dataProvider.values = _exportNodes(_nodes);
                     if (dispatch) {
                         _broadcastNodesChange();
                     }
@@ -311,32 +302,30 @@
              * Rewrites the values of all selected nodes, optionally also dispatching
              * a `NODES_CHANGE` and a `SELECTION_CHANGE` NodalEvents.
              */
-            public function patchSelection(patch:Object, dispatch:Boolean = false):void {
-                if (!patch || !patch.selectedNodes || !patch.selectedNodes.length ||
+            public function patchSelection(patch:SelectionDetails, dispatch:Boolean = false):void {
+                if (!patch || !patch.selectedValues || !patch.selectedValues.length ||
                         !_selectionManager || !_nodes || !_nodes.length ||
                         !_dataProvider) {
                     return;
                 }
-            
+
                 const selectedNodes:Vector.<Node> = _selectionManager.selectedNodes;
                 if (!selectedNodes || !selectedNodes.length) {
                     return;
                 }
-            
-                if (selectedNodes.length != selectedNodes.length) {
+
+                if (selectedNodes.length != patch.selectedValues.length) {
                     return;
                 }
-            
+
                 _dragBoundsChanged = true;
-                const patchedNodes:Array = patch.selectedNodes;
+                const patchedNodes:Vector.<Point> = patch.selectedValues;
                 for (var i:int = 0; i < patchedNodes.length; i++) {
-                    const p:Array = patchedNodes[i];
-                    const pValue:Number = p[1];
-                    selectedNodes[i].logicalY = pValue;
+                    const p:Point = patchedNodes[i];
+                    selectedNodes[i].logicalY = p.y;
                 }
-            
+
                 invalidateDisplayList();
-                _dataProvider.values = _exportNodes(_nodes);
                 if (dispatch) {
                     _broadcastNodesChange();
                     _broadcastSelection();
@@ -566,7 +555,6 @@
                 invalidateDisplayList();
             
                 // Broadcast the changes.
-                _dataProvider.values = _exportNodes(_nodes);
                 if (dispatch) {
                     _broadcastNodesChange();
                 }
@@ -575,45 +563,41 @@
             }
             
             /**
-             * Converts a single Node to an [x,y] doublet. Returns null for a missing Node.
+             * Converts a single Node to a Point. Returns null for a missing Node.
              */
-            private function _exportNode(node:Node):Array {
-                if (!node) {
-                    return null;
-                }
-                return [node.logicalX, node.logicalY];
+            private function _nodeToPoint(node:Node):Point {
+                return node ? new Point(node.logicalX, node.logicalY) : null;
             }
-            
+
             /**
-             * Converts several nodes to [x,y] doublets and appends them to storage.
-             * Does nothing if missing `nodes` or `storage`.
+             * Converts several nodes to Points and appends them to storage.
+             * Synthetic nodes are ignored.
              */
-            private function _exportNodes(nodes:Vector.<Node>):Array {
-                const out:Array = [];
+            private function _nodesToPoints(nodes:Vector.<Node>):Vector.<Point> {
+                var out:Vector.<Point> = new <Point>[];
                 if (!nodes || !nodes.length) {
                     return out;
                 }
                 for each (var node:Node in nodes) {
-                    // We do not export synthetic nodes.
                     if (node.isSynthetic) {
                         continue;
                     }
-                    out.push(_exportNode(node));
+                    out.push(_nodeToPoint(node));
                 }
                 return out;
             }
-            
+
             /**
              * Parses incoming values into nodes.
              */
-            private function _importValues(values:Array):Vector.<Node> {
+            private function _importValues(values:Vector.<Point>):Vector.<Node> {
                 var nodes:Vector.<Node> = new <Node>[];
-            
+
                 const numValues:uint = values ? values.length : 0;
                 for (var i:int = 0; i < numValues; i++) {
-                    nodes.push(new Node(values[i][0], values[i][1], false));
+                    nodes.push(new Node(values[i].x, values[i].y, false));
                 }
-            
+
                 nodes = _proofNodes(nodes);
                 return nodes;
             }
@@ -779,7 +763,6 @@
                                 _dragBoundsChanged = true;
                             }
                             invalidateDisplayList();
-                            _dataProvider.values = _exportNodes(_nodes);
                         }
                         break;
             
@@ -932,7 +915,6 @@
                     node.logicalY = Math.max(0, Math.min(1, ly));
                 }
             
-                _dataProvider.values = _exportNodes(_nodes);
                 _broadcastNodesChange();
             
                 // Rebroadcast selection, as selected values might have changed despite
@@ -950,18 +932,24 @@
              * Sends out information about the current chart selection.
              */
             private function _broadcastSelection():void {
-                dispatchEvent(new NodalEvent(NodalEvent.SELECTION_CHANGE, {
-                                selectedNodes: _exportNodes(_selectionManager.selectedNodes),
-                                selectedNode: _exportNode(_selectionManager.selectedNode),
-                                anchorNode: _exportNode(_selectionManager.anchorNode)
-                            }));
+                var details:SelectionDetails = new SelectionDetails(
+                    _nodeToPoint(_selectionManager.selectedNode),
+                    _nodesToPoints(_selectionManager.selectedNodes),
+                    _nodeToPoint(_selectionManager.anchorNode)
+                );
+                dispatchEvent(new SelectionEvent(NodalEvent.SELECTION_CHANGE,
+                    _dataProvider ? _dataProvider.uid : null, details));
             }
-            
+
             /**
              * Sends out information about the changed nodes.
              */
             private function _broadcastNodesChange():void {
-                dispatchEvent(new NodalEvent(NodalEvent.NODES_CHANGE));
+                if (!_dataProvider) {
+                    return;
+                }
+                var edit:ChartEdit = new ChartEdit(_dataProvider.uid, _nodesToPoints(_nodes), _chartName);
+                dispatchEvent(new ChartEditEvent(NodalEvent.NODES_CHANGE, _dataProvider.uid, edit));
             }
             
             /**

--- a/src/com/github/ciacob/flexnodal/components/SelectionPanel.mxml
+++ b/src/com/github/ciacob/flexnodal/components/SelectionPanel.mxml
@@ -12,7 +12,7 @@
     width="100%">
 
     <fx:Metadata>
-        [Event(name="selectionPatch", type="com.github.ciacob.flexnodal.events.NodalEvent")]
+        [Event(name="selectionPatch", type="com.github.ciacob.flexnodal.events.SelectionEvent")]
         
         [Style(name="headerStyle", type="String", inherit="false")]
         [Style(name="bodyStyle", type="String", inherit="false")]
@@ -22,8 +22,11 @@
     <fx:Script>
         <![CDATA[
             import spark.components.NumericStepper;
+            import com.github.ciacob.flexnodal.events.SelectionEvent;
             import com.github.ciacob.flexnodal.events.NodalEvent;
             import com.github.ciacob.flexnodal.utils.Helpers;
+            import com.github.ciacob.flexnodal.utils.SelectionDetails;
+            import flash.geom.Point;
             
             // The name of the current chart; displayed at the top of the panel.
             [Bindable]
@@ -113,7 +116,7 @@
             // ---------------------------
             
             // Internal storage for the `dataProvider` property
-            private var _dataProvider:Object;
+            private var _dataProvider:SelectionDetails;
             
             // Flag we raise when the `dataProvider` property has been externally changed
             private var _dataProviderChanged:Boolean;
@@ -122,40 +125,18 @@
              * Returns the current data provider of this component. Reflects internal
              * changes.
              */
-            public function get dataProvider():Object {
+            public function get dataProvider():SelectionDetails {
                 return _dataProvider;
             }
             
             /**
              * Sets or replaces a data provider for this component.
              * @param   value
-             *          A user provided dataset to be used as data provider.
-             *          Must pass validation in order to be accepted. Example of
-             *          valid datasets:
-             *
-             *          Single selection:
-             *          {
-             *              "selectedNode":[0.5,0.8],
-             *              "anchorNode":[0.5,0.8],
-             *              "selectedNodes":[[0.5,0.8]]
-             *          }
-             *
-             *          Multiple selection:
-             *          {
-             *              "selectedNode":[1,0],
-             *              "anchorNode":[1,0],
-             *              "selectedNodes":[[0.5,0.8],[0.95,0],[1,0]]
-             *          }
-             *
-             *          If a provided dataset does not pass validation, `null` is
-             *          assumed instead.
-             *
-             *          N.B.: The component operates destructively on the provided
-             *          dataset rather than on a detached copy. This is by design.
+             *          Immutable selection details describing the current context.
              */
-            public function set dataProvider(value:Object):void {
+            public function set dataProvider(value:SelectionDetails):void {
                 if (value !== _dataProvider) {
-                    _dataProvider = _validateDataProvider(value) ? value : null;
+                    _dataProvider = value;
                     _dataProviderChanged = true;
                     invalidateProperties();
                 }
@@ -184,23 +165,23 @@
                     _dataProviderChanged = false;
                     _clearCache();
                     if (_dataProvider) {
-                        _numNodes = _dataProvider.selectedNodes.length;
+                        _numNodes = _dataProvider.selectedValues.length;
                         if (_numNodes) {
-            
+
                             // Common to single and multiple selection scenarios
-                            const selectedNode:Array = _dataProvider.selectedNode;
-                            _currValue = Helpers.toPercent(selectedNode[1]);
+                            const selectedNode:Point = _dataProvider.selectedValue;
+                            _currValue = Helpers.toPercent(selectedNode.y);
                             _currNodeTime = (Helpers.timeToLabel !== null) ?
-                                Helpers.timeToLabel(selectedNode[0]) : "";
-            
+                                Helpers.timeToLabel(selectedNode.x) : "";
+
                             // Multiple selection scenario
                             if (_numNodes > 1) {
-                                const stats:Object = Helpers.analyzeY(_dataProvider.selectedNodes);
+                                const stats:Object = Helpers.analyzeY(_dataProvider.selectedValues);
                                 _minRangeValue = Helpers.toPercent(stats.min);
                                 _maxRangeValue = Helpers.toPercent(stats.max);
                                 _avgRangeValue = Helpers.toPercent(stats.avg);
-            
-                                const hash:String = _hashSelectionContext(chartName, _dataProvider.selectedNodes);
+
+                                const hash:String = _hashSelectionContext(chartName, _dataProvider.selectedValues);
                                 if (hash !== _selectionHash) {
                                     _selectionHash = hash;
                                     _offsetMin = Helpers.toPercent(-stats.min);
@@ -220,10 +201,10 @@
              * based on given `chartName` and `selectedNodes`. Relies on the fact that
              * selected nodes maintain their indices and "y" values when patched.
              */
-            private function _hashSelectionContext(chartName:String, selectedNodes:Array):String {
+            private function _hashSelectionContext(chartName:String, selectedNodes:Vector.<Point>):String {
                 const tokens:Array = [chartName || ""];
                 for (var i:int = 0; i < selectedNodes.length; i++) {
-                    tokens.push(i + '-' + selectedNodes[i][0]);
+                    tokens.push(i + '-' + selectedNodes[i].x);
                 }
                 return tokens.join(',');
             }
@@ -255,136 +236,34 @@
             }
             
             /**
-             * Formally validates the received `dataProvider`. Expected format is, e.g.:
-             * {
-             *      "selectedNode":[1,0],
-             *      "anchorNode":[1,0],
-             *      "selectedNodes":[[0,0.1],[0.5,0.8],[0.95,0],[1,0]]
-             * }
+             * Creates a new SelectionDetails instance by applying `value` (or an offset)
+             * to all Y coordinates found in the provided selection.
              */
-            private function _validateDataProvider(dataProvider:Object):Boolean {
-                if (!dataProvider) {
-                    return false;
-                }
-                const expectedProps:Array = ['selectedNode', 'anchorNode', 'selectedNodes'];
-                for each (var propName:String in expectedProps) {
-                    if (!dataProvider.hasOwnProperty(propName)) {
-                        return false;
-                    }
-                    if (!(dataProvider[propName] is Array)) {
-                        return false;
-                    }
-                    if ((dataProvider[propName] as Array).length === 0) {
-                        return false;
-                    }
-            
-                    const validatorFn:Function = (propName === 'selectedNodes') ?
-                        _validateDoublets : _validateDoublet;
-                    if (!validatorFn(dataProvider[propName] as Array)) {
-                        return false;
-                    }
-                }
-            
-                return true;
-            }
-            
-            /**
-             * Validates the given `doublets` Array as an Array of legitimate doublets.
-             *
-             * @param   doublets
-             *          Assumed non-null Array to validate.
-             */
-            private function _validateDoublets(doublets:Array):Boolean {
-                for (var i:int = 0; i < doublets.length; i++) {
-                    if (!_validateDoublet(doublets[i])) {
-                        return false;
-                    }
-                }
-                return true;
-            }
-            
-            /**
-             * Validates the given `doublet` as an Array of exactly two valid
-             * numeric values.
-             *
-             * @param   doublet
-             *          Assumed non-null Array to validate.
-             */
-            private function _validateDoublet(doublet:Array):Boolean {
-                return (doublet.length === 2 &&
-                        !isNaN(doublet[0]) && !isNaN(doublet[1]));
-            }
-            
-            /**
-             * Sets given `value` in all doublets found inside the given `dp`.
-             * @param   dp
-             *          Either `null` or a previously validated data provider.
-             *
-             * @param   value
-             *          Either `NaN` or a previously validated Number.
-             *
-             * @param   value
-             *          Whether given `value` should be treated as absolute or an offset.
-             */
-            private function _patchDataProvider(dp:Object, value:Number, offsetMode:Boolean = false):void {
+            private function _patchDataProvider(dp:SelectionDetails, value:Number, offsetMode:Boolean = false):SelectionDetails {
                 if (!dp || isNaN(value)) {
-                    return;
+                    return dp;
                 }
-            
-                for (var propName:String in dp) {
-                    const dataset:Array = dp[propName] as Array;
-                    const patcherFn:Function = (propName === 'selectedNodes') ?
-                        _patchDoublets : _patchDoublet;
-                    patcherFn(dataset, value, offsetMode);
+
+                var patchedValues:Vector.<Point> = new <Point>[];
+                for each (var p:Point in dp.selectedValues) {
+                    patchedValues.push(_patchPoint(p, value, offsetMode));
                 }
-            
+
+                var selectedValue:Point = _patchPoint(dp.selectedValue, value, offsetMode);
+                var anchor:Point = _patchPoint(dp.selectionAnchor, value, offsetMode);
+
                 _dataProviderChanged = true;
                 invalidateProperties();
+                return new SelectionDetails(selectedValue, patchedValues, anchor);
             }
-            
-            /**
-             * Patches the given `doublets` Array by replacing the second item of
-             * each `doublet` with given `value`.
-             *
-             * @param   doublet
-             *          Assumed non-null and validated doublets Array to patch.
-             *
-             * @param   value
-             *          Assumed valid Number to use.
-             *
-             * @param   offsetMode
-             *          optional. If `true`, treats received `value` as an offset.
-             */
-            private function _patchDoublets(doublets:Array, value:Number, offsetMode:Boolean = false):void {
-                for (var i:int = 0; i < doublets.length; i++) {
-                    _patchDoublet(doublets[i], value, offsetMode);
+
+            private function _patchPoint(src:Point, value:Number, offsetMode:Boolean = false):Point {
+                if (!src) {
+                    return null;
                 }
-            }
-            
-            /**
-             * Patches the given `doublet` by replacing its second item with
-             * given `value`.
-             *
-             * @param   doublet
-             *          Assumed non-null and validated doublet Array to patch.
-             *
-             * @param   newValue
-             *          Assumed valid Number to use.
-             *
-             * @param   offsetMode
-             *          optional. If `true`, treats received `value` as an offset.
-             */
-            private function _patchDoublet(doublet:Array, newValue:Number, offsetMode:Boolean = false):void {
-                var value:Number = doublet[1];
-                if (offsetMode) {
-                    value += newValue;
-                }
-                else {
-                    value = newValue;
-                }
-            
-                value = Math.max(0, Math.min(1, value));
-                doublet[1] = value;
+                var y:Number = offsetMode ? src.y + value : value;
+                y = Math.max(0, Math.min(1, y));
+                return new Point(src.x, y);
             }
             
             /**
@@ -400,8 +279,8 @@
                 }
             
                 const value:Number = Helpers.fromPercent(percent);
-                _patchDataProvider(_dataProvider, value);
-                dispatchEvent(new NodalEvent(NodalEvent.SELECTION_PATCH, _dataProvider));
+                _dataProvider = _patchDataProvider(_dataProvider, value);
+                dispatchEvent(new SelectionEvent(NodalEvent.SELECTION_PATCH, chartName, _dataProvider));
             }
             
             /**
@@ -425,13 +304,14 @@
             
                 // Calculate the delta/displacement relative to the last
                 // known value.
+                var deltaValue:Number = value;
                 if (offsetMode) {
-                    const deltaValue:Number = (value - _currOffset);
+                    deltaValue = (value - _currOffset);
                     _currOffset = value;
                 }
-            
-                _patchDataProvider(_dataProvider, offsetMode ? deltaValue : value, offsetMode);
-                dispatchEvent(new NodalEvent(NodalEvent.SELECTION_PATCH, _dataProvider));
+
+                _dataProvider = _patchDataProvider(_dataProvider, offsetMode ? deltaValue : value, offsetMode);
+                dispatchEvent(new SelectionEvent(NodalEvent.SELECTION_PATCH, chartName, _dataProvider));
             }
             
             /**

--- a/src/com/github/ciacob/flexnodal/events/ChartEditEvent.as
+++ b/src/com/github/ciacob/flexnodal/events/ChartEditEvent.as
@@ -16,7 +16,7 @@ package com.github.ciacob.flexnodal.events {
         }
 
         override public function clone():Event {
-            return new ChartEditEvent (type, String(payload), _edit, bubbles, cancelable);
+            return new ChartEditEvent(type, uid, _edit, bubbles, cancelable);
         }
     }
 }

--- a/src/com/github/ciacob/flexnodal/events/SelectionEvent.as
+++ b/src/com/github/ciacob/flexnodal/events/SelectionEvent.as
@@ -16,7 +16,7 @@ package com.github.ciacob.flexnodal.events {
         }
 
         override public function clone():Event {
-            return new SelectionEvent(type, String(payload), _details, bubbles, cancelable);
+            return new SelectionEvent(type, uid, _details, bubbles, cancelable);
         }
     }
 }

--- a/src/com/github/ciacob/flexnodal/utils/ChartDescriptor.as
+++ b/src/com/github/ciacob/flexnodal/utils/ChartDescriptor.as
@@ -38,7 +38,7 @@ package com.github.ciacob.flexnodal.utils {
         }
 
         public function get dashStyle():Vector.<Number> {
-            return _dashStyle ? _dashStyle.concat() : null;
+            return (_dashStyle && _dashStyle.length > 0) ? _dashStyle.concat() : null;
         }
     }
 }

--- a/src/com/github/ciacob/flexnodal/utils/Helpers.as
+++ b/src/com/github/ciacob/flexnodal/utils/Helpers.as
@@ -2,6 +2,7 @@ package com.github.ciacob.flexnodal.utils {
 
     import mx.core.UIComponent;
     import mx.styles.CSSStyleDeclaration;
+    import flash.geom.Point;
 
     /**
      * Holder for various (potentially) generic helper functions.
@@ -354,18 +355,18 @@ package com.github.ciacob.flexnodal.utils {
          * minimum, maximum and average values.
          *
          * @param   `nodes`
-         *           Assumed valid, non-empty Array of valid doublets.
+         *           Assumed valid, non-empty Vector of Points.
          *
          * @return  An Object similar to:
          *          {min: 0, max: 0.5, avg: 1}
          */
-        public static function analyzeY(nodes:Array):Object {
+        public static function analyzeY(nodes:Vector.<Point>):Object {
             var sum:Number = 0;
             var min:Number = Number.MAX_VALUE;
             var max:Number = -Number.MAX_VALUE;
 
-            for each (var node:Array in nodes) {
-                var y:Number = node[1];
+            for each (var node:Point in nodes) {
+                var y:Number = node.y;
                 if (y < min) {
                     min = y;
                 }


### PR DESCRIPTION
## Summary
- Type chart `dataProvider` with `ChartDescriptor`
- Use `Point` and `Vector.<Point>` instead of doublets
- Dispatch `SelectionEvent` and `ChartEditEvent` with rich details

------
https://chatgpt.com/codex/tasks/task_e_68bed00f76888329971e3aaf2827e528